### PR TITLE
Add samtools and bcftools Docker image

### DIFF
--- a/tools/samtools/Dockerfile
+++ b/tools/samtools/Dockerfile
@@ -1,0 +1,99 @@
+ARG SAMTOOLS_VERSION=1.21
+ARG BCFTOOLS_VERSION=1.21
+ARG HTSLIB_VERSION=1.21
+
+# Build stage
+FROM debian:bookworm-slim AS builder
+LABEL maintainer="Yuelong CHEN <yuelong.chen.btr@gmail.com>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ARG SAMTOOLS_VERSION
+ARG BCFTOOLS_VERSION
+ARG HTSLIB_VERSION
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        ca-certificates \
+        zlib1g-dev \
+        libbz2-dev \
+        liblzma-dev \
+        libncurses-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libdeflate-dev \
+        autoconf \
+        automake \
+        bzip2 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/build
+
+# Build htslib first (required by samtools and bcftools)
+RUN curl -L https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2 | tar -jxf - && \
+    cd htslib-${HTSLIB_VERSION} && \
+    ./configure --prefix=/usr/local --enable-libcurl --enable-plugins && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig
+
+# Build samtools
+RUN curl -L https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2 | tar -jxf - && \
+    cd samtools-${SAMTOOLS_VERSION} && \
+    ./configure --prefix=/usr/local --with-htslib=/usr/local --without-curses && \
+    make -j$(nproc) && \
+    make install && \
+    strip /usr/local/bin/samtools
+
+# Build bcftools
+RUN curl -L https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 | tar -jxf - && \
+    cd bcftools-${BCFTOOLS_VERSION} && \
+    ./configure --prefix=/usr/local --with-htslib=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    strip /usr/local/bin/bcftools
+
+# Runtime stage
+FROM debian:bookworm-slim
+LABEL maintainer="Yuelong CHEN <yuelong.chen.btr@gmail.com>"
+LABEL org.opencontainers.image.source="https://github.com/loganylchen/dockerfiles"
+LABEL org.opencontainers.image.description="Samtools and BCFtools for BAM/VCF manipulation"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ARG SAMTOOLS_VERSION
+ARG BCFTOOLS_VERSION
+ARG HTSLIB_VERSION
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        zlib1g \
+        libbz2-1.0 \
+        liblzma5 \
+        libcurl4 \
+        libssl3 \
+        libdeflate0 \
+        perl \
+        && rm -rf /var/lib/apt/lists/* \
+        && apt-get clean
+
+# Copy binaries and libraries from builder
+COPY --from=builder /usr/local/bin/samtools /usr/local/bin/
+COPY --from=builder /usr/local/bin/bcftools /usr/local/bin/
+COPY --from=builder /usr/local/lib/libhts* /usr/local/lib/
+COPY --from=builder /usr/local/lib/pkgconfig /usr/local/lib/pkgconfig
+COPY --from=builder /usr/local/include/htslib /usr/local/include/htslib
+
+# Update library cache
+RUN ldconfig
+
+# Create working directory
+WORKDIR /data
+
+# Verify installations
+RUN samtools --version && bcftools --version
+
+# Default command
+CMD ["samtools"]

--- a/tools/samtools/README.md
+++ b/tools/samtools/README.md
@@ -1,0 +1,96 @@
+# Samtools & BCFtools Docker Image
+
+[![Build Status](https://github.com/loganylchen/dockerfiles/actions/workflows/docker-build.yml/badge.svg)](https://github.com/loganylchen/dockerfiles/actions/workflows/docker-build.yml)
+
+Docker image for **samtools** and **bcftools**, the standard tools for manipulating BAM/CRAM/SAM and VCF/BCF files.
+
+## Included Tools
+
+| Tool | Version | Description |
+|------|---------|-------------|
+| samtools | 1.21 | Utilities for the Sequence Alignment/Map (SAM) format |
+| bcftools | 1.21 | Utilities for variant calling and manipulating VCF/BCF files |
+| htslib | 1.21 | Underlying library for reading/writing SAM/BAM/CRAM/VCF/BCF |
+
+## Quick Start
+
+```bash
+# Pull the image
+docker pull btrspg/samtools:1.21
+
+# View a BAM file header
+docker run --rm -v /path/to/data:/data btrspg/samtools:1.21 samtools view -H /data/alignment.bam
+
+# Sort a BAM file
+docker run --rm -v /path/to/data:/data btrspg/samtools:1.21 \
+    samtools sort -o /data/sorted.bam /data/alignment.bam
+
+# Index a BAM file
+docker run --rm -v /path/to/data:/data btrspg/samtools:1.21 \
+    samtools index /data/alignment.bam
+
+# Call variants with bcftools
+docker run --rm -v /path/to/data:/data btrspg/samtools:1.21 \
+    bcftools mpileup -f /data/reference.fa /data/alignment.bam | \
+    bcftools call -mv -o /data/variants.vcf
+```
+
+## Common Use Cases in RNA Modification Detection
+
+### 1. Convert SAM to BAM and sort
+```bash
+samtools view -bS input.sam | samtools sort -o sorted.bam
+samtools index sorted.bam
+```
+
+### 2. Filter reads by mapping quality
+```bash
+samtools view -b -q 20 input.bam -o filtered.bam
+```
+
+### 3. Extract reads from specific region
+```bash
+samtools view -b input.bam chr1:1000-2000 -o region.bam
+```
+
+### 4. Get alignment statistics
+```bash
+samtools flagstat input.bam
+samtools stats input.bam | samtools plot-bamstats -p /output/prefix
+```
+
+### 5. Merge multiple BAM files
+```bash
+samtools merge merged.bam sample1.bam sample2.bam sample3.bam
+samtools index merged.bam
+```
+
+## Build
+
+```bash
+docker build -t btrspg/samtools:1.21 .
+```
+
+## Build Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `SAMTOOLS_VERSION` | 1.21 | Samtools version |
+| `BCFTOOLS_VERSION` | 1.21 | Bcftools version |
+| `HTSLIB_VERSION` | 1.21 | HTSlib version |
+
+## Related Images
+
+- `btrspg/minimap2` - Includes samtools alongside minimap2
+- `btrspg/nanopolish` - For signal-level analysis
+
+## References
+
+- [Samtools Documentation](http://www.htslib.org/doc/samtools.html)
+- [BCFtools Documentation](http://www.htslib.org/doc/bcftools.html)
+- [HTSlib Documentation](http://www.htslib.org/)
+
+## License
+
+- Samtools/BCFtools/HTSlib: MIT/BSD-like license
+- This Dockerfile: MIT License


### PR DESCRIPTION
## Summary

This PR adds a Dockerfile for **samtools** and **bcftools**, the standard tools for manipulating BAM/CRAM/SAM and VCF/BCF files.

## Motivation

- Fixes #28 (samtools portion)
- The current `btrspg/minimap2` image includes samtools but the naming is confusing
- A dedicated samtools image provides clarity and proper versioning
- Includes bcftools which is commonly used alongside samtools

## Changes

### New Files
- `tools/samtools/Dockerfile` - Multi-stage build for samtools, bcftools, and htslib
- `tools/samtools/README.md` - Documentation with usage examples

### Features
| Tool | Version | Description |
|------|---------|-------------|
| samtools | 1.21 | BAM/CRAM/SAM file manipulation |
| bcftools | 1.21 | VCF/BCF variant calling |
| htslib | 1.21 | Underlying library |

### Build Details
- Multi-stage build for smaller image size
- Based on `debian:bookworm-slim`
- Builds from source with HTSlib support
- Includes libcurl support for remote file access

## Testing

```bash
cd tools/samtools
docker build -t samtools-test:1.21 .
docker run --rm samtools-test:1.21 samtools --version
docker run --rm samtools-test:1.21 bcftools --version
```

## Usage Example

```bash
# Pull and use
docker pull btrspg/samtools:1.21

# Sort and index a BAM file
docker run --rm -v /path/to/data:/data btrspg/samtools:1.21 \
    sh -c "samtools sort -o /data/sorted.bam /data/input.bam && samtools index /data/sorted.bam"
```

## Related
- Addresses #28 (samtools portion)