### PR TITLE
feat(isotools): add python alias via python-is-python3

### DIFF
--- a/tools/isotools/Dockerfile
+++ b/tools/isotools/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 \
         python3-pip \
         python3-dev \
+        python-is-python3 \
         gcc \
         g++ \
         zlib1g-dev \
@@ -30,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* /root/.cache /tmp/*
 
 RUN python3 -c "import isotools; print('isotools', isotools.__version__)" \
+    && python -c "import sys; print('python ->', sys.executable)" \
     && run_isotools --help > /dev/null
 
 WORKDIR /data


### PR DESCRIPTION
## Summary
- Add `python-is-python3` to the isotools image so `python` resolves to `python3`.
- Add a build-time verification line confirming the alias works.

## Why
The `btrspg/isotools` image ships only `python3`. When consumed by a Snakemake workflow running a Python `script:` directive inside the container under `--use-singularity`, Snakemake hardcodes the interpreter name as `python` (not `python3`) when a container image is set — there is no override. The bare `python` lookup therefore fails with exit 127 on this image.

Adding `python-is-python3` resolves this and matches the convention already used by 10 other tools in this repo (liqa, dexseq, suppa, rmatsturbo, junctionseq, epinano, leafcutter, gatk, sicelore, drummer).

## Test plan
- [ ] `docker build -t isotools:0.3.4 --build-arg VERSION=0.3.4 tools/isotools` succeeds
- [ ] Build-time verification prints `python -> /usr/bin/python3`
- [ ] `import isotools` and `run_isotools --help` still pass